### PR TITLE
Release/v2.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-container",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-container",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-container",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Manage isolated Docker containers for running coding tools on different projects",
   "main": "dist/main.js",
   "bin": {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -70,7 +70,7 @@ export function ensureDockerfile(): void {
 export function buildImageRaw(): boolean {
   const baseResult = spawnSync(
     "docker",
-    ["build", "-t", `${BASE_IMAGE}:${IMAGE_TAG}`, "-f", PACKAGED_DOCKERFILE, APPDATA_DIR],
+    ["build", "--no-cache", "-t", `${BASE_IMAGE}:${IMAGE_TAG}`, "-f", PACKAGED_DOCKERFILE, APPDATA_DIR],
     { stdio: "inherit" }
   );
   if (baseResult.status !== 0) return false;
@@ -79,7 +79,7 @@ export function buildImageRaw(): boolean {
 
   const userResult = spawnSync(
     "docker",
-    ["build", "-f", USER_DOCKERFILE_PATH, "-t", `${IMAGE_NAME}:${IMAGE_TAG}`, APPDATA_DIR],
+    ["build", "--no-cache", "-f", USER_DOCKERFILE_PATH, "-t", `${IMAGE_NAME}:${IMAGE_TAG}`, APPDATA_DIR],
     { stdio: "inherit" }
   );
   return userResult.status === 0;

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -102,7 +102,7 @@ export function containerRunning(containerName: string): boolean {
 }
 
 export function stopContainer(containerName: string): void {
-  spawnSync("docker", ["stop", "--timeout", "3", containerName], { stdio: "inherit" });
+  spawnSync("docker", ["stop", "-t", "3", containerName], { stdio: "inherit" });
 }
 
 export function startContainer(containerName: string): void {


### PR DESCRIPTION
* `container build` will rebuild with no cache
* exiting from a container will use `-t` flag for backwards compatibility