### PR TITLE
feat: non-root user with host UID/GID and selectable harness installation

### DIFF
--- a/resources/Dockerfile.Core
+++ b/resources/Dockerfile.Core
@@ -16,11 +16,37 @@ RUN apt-get update && apt-get install -y \
     zlib1g-dev \
     libffi-dev \
     vim \
-    tree
+    tree \
+    jq \
+    sudo \
+    python3 \
+    python3-dev \
+    python3-venv \
+    python3-pip
+
+# Build args for host UID/GID mapping
+ARG CONTAINER_UID=1000
+ARG CONTAINER_GID=1000
+ARG CONTAINER_USER=developer
+
+# Create non-root user with host UID/GID
+RUN if getent group $CONTAINER_GID > /dev/null 2>&1; then \
+        groupmod -n $CONTAINER_USER `getent group $CONTAINER_GID | cut -d: -f1`; \
+    else \
+        groupadd -g $CONTAINER_GID $CONTAINER_USER; \
+    fi && \
+    if id -u $CONTAINER_UID > /dev/null 2>&1; then \
+        existing_user=`id -un $CONTAINER_UID`; \
+        if [ "$existing_user" != "$CONTAINER_USER" ]; then \
+            userdel "$existing_user" 2>/dev/null || true; \
+        fi; \
+    fi && \
+    useradd -m -u $CONTAINER_UID -g $CONTAINER_GID -s /bin/bash $CONTAINER_USER && \
+    echo "$CONTAINER_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Install NVM (Node Version Manager) and Node.js
 ENV NVM_DIR=/root/.nvm
-ENV NODE_VERSION=22
+ENV NODE_VERSION=24
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
     && . "$NVM_DIR/nvm.sh" \
     && nvm install ${NODE_VERSION} \
@@ -28,26 +54,22 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     && nvm alias default ${NODE_VERSION} \
     && ln -sf "$NVM_DIR/versions/node/$(nvm current)/bin/"* /usr/local/bin/
 
-RUN apt-get update \
-    && apt-get install -y \
-        python3 \
-        python3-dev \
-        python3-venv \
-        python3-pip
-
 # Create python symlink pointing to python3
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
-# Set working directory to root home
-WORKDIR /root
+# Set working directory
+WORKDIR /home/$CONTAINER_USER
 
-# Configure bash prompt to show container name
-RUN echo 'PS1="\[\033[01;32m\][code-container]\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$ "' >> /root/.bashrc
+# Configure bash prompt for developer user
+RUN echo 'PS1="\[\033[01;32m\][code-container]\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$ "' >> /home/$CONTAINER_USER/.bashrc
 
 # Source NVM in bashrc for interactive shells
-RUN echo 'export NVM_DIR="$HOME/.nvm"' >> /root/.bashrc \
-    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /root/.bashrc \
-    && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"' >> /root/.bashrc
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> /home/$CONTAINER_USER/.bashrc \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /home/$CONTAINER_USER/.bashrc \
+    && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"' >> /home/$CONTAINER_USER/.bashrc
+
+# Ensure developer owns home directory
+RUN chown -R $CONTAINER_USER:$CONTAINER_USER /home/$CONTAINER_USER
 
 # Default command: bash shell
 CMD ["/bin/bash"]

--- a/resources/Dockerfile.Harness
+++ b/resources/Dockerfile.Harness
@@ -1,12 +1,34 @@
 FROM code-container-packages:latest
 
-RUN curl -fsSL https://claude.ai/install.sh | bash
-RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+ARG INSTALL_CLAUDE=false
+ARG INSTALL_OPENCODE=false
+ARG INSTALL_CODEX=false
+ARG INSTALL_GEMINI=false
+ARG INSTALL_COPILOT=false
 
-RUN npm install -g opencode-ai
+ARG CONTAINER_USER=developer
 
-RUN npm install -g @openai/codex
+RUN if [ "$INSTALL_CLAUDE" = "true" ]; then \
+      curl -fsSL https://claude.ai/install.sh | bash && \
+      cp /root/.local/bin/claude /usr/local/bin/claude 2>/dev/null; \
+      cp /root/.local/bin/claude-code /usr/local/bin/claude-code 2>/dev/null; \
+    fi
 
-RUN npm install -g @google/gemini-cli
+RUN if [ "$INSTALL_OPENCODE" = "true" ]; then \
+      npm install -g opencode-ai; \
+    fi
 
-RUN npm install -g @github/copilot
+RUN if [ "$INSTALL_CODEX" = "true" ]; then \
+      npm install -g @openai/codex; \
+    fi
+
+RUN if [ "$INSTALL_GEMINI" = "true" ]; then \
+      npm install -g @google/gemini-cli; \
+    fi
+
+RUN if [ "$INSTALL_COPILOT" = "true" ]; then \
+      npm install -g @github/copilot; \
+    fi
+
+# Ensure developer user has CLI tools in PATH
+RUN echo 'export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"' >> /home/$CONTAINER_USER/.bashrc

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -34,8 +34,9 @@ import {
 } from "./config";
 
 export function buildImage(target: BuildTarget): void {
+  const settings = loadSettings();
   printInfo(`Building Docker image: ${IMAGE_NAME}:${IMAGE_TAG}`);
-  if (!buildImageRaw(target)) {
+  if (!buildImageRaw(target, settings.containerUid, settings.containerGid)) {
     printError("Failed to build Docker image");
     process.exit(1);
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -31,12 +31,28 @@ import {
   loadSettings,
   saveSettings,
   copyConfigs,
+  HARNESS_LIST,
 } from "./config";
 
-export function buildImage(target: BuildTarget): void {
+export async function buildImage(target: BuildTarget): Promise<void> {
   const settings = loadSettings();
+  const uid = settings.containerUid;
+  const gid = settings.containerGid;
+
+  let selectedHarnesses = settings.selectedHarnesses;
+  if (selectedHarnesses.length === 0) {
+    printInfo("No harnesses selected. Please choose which to install:");
+    selectedHarnesses = [];
+    for (const harness of HARNESS_LIST) {
+      const install = await promptYesNo(`Install ${harness}?`);
+      if (install) selectedHarnesses.push(harness);
+    }
+    settings.selectedHarnesses = selectedHarnesses;
+    saveSettings(settings);
+  }
+
   printInfo(`Building Docker image: ${IMAGE_NAME}:${IMAGE_TAG}`);
-  if (!buildImageRaw(target, settings.containerUid, settings.containerGid)) {
+  if (!buildImageRaw(target, uid, gid, selectedHarnesses)) {
     printError("Failed to build Docker image");
     process.exit(1);
   }
@@ -107,7 +123,7 @@ export async function runContainer(
 
   if (!imageExists()) {
     printWarning("Docker image not found. Building...");
-    buildImage("full");
+    await buildImage("full");
   }
 
   if (containerRunning(containerName)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,9 +30,18 @@ const SettingsSchema = z.object({
   acceptedTos: z.boolean().default(false),
   containerUid: z.number().default(1000),
   containerGid: z.number().default(1000),
+  selectedHarnesses: z.array(z.string()).default([]),
 });
 
 export type Settings = z.infer<typeof SettingsSchema>;
+
+export const HARNESS_LIST = [
+  "claude-code",
+  "opencode",
+  "codex",
+  "gemini",
+  "copilot",
+] as const;
 
 export function ensureAppdataDir(): void {
   if (!fs.existsSync(APPDATA_DIR)) {
@@ -49,6 +58,7 @@ export function loadSettings(): Settings {
       acceptedTos: false,
       containerUid: 1000,
       containerGid: 1000,
+      selectedHarnesses: [],
     };
   }
   const content = fs.readFileSync(SETTINGS_PATH, "utf-8");

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,8 @@ export const SHARED_DIRS = [
 const SettingsSchema = z.object({
   completedInit: z.boolean().default(false),
   acceptedTos: z.boolean().default(false),
+  containerUid: z.number().default(1000),
+  containerGid: z.number().default(1000),
 });
 
 export type Settings = z.infer<typeof SettingsSchema>;
@@ -42,7 +44,12 @@ export function ensureAppdataDir(): void {
 
 export function loadSettings(): Settings {
   if (!fs.existsSync(SETTINGS_PATH)) {
-    return { completedInit: false, acceptedTos: false };
+    return {
+      completedInit: false,
+      acceptedTos: false,
+      containerUid: 1000,
+      containerGid: 1000,
+    };
   }
   const content = fs.readFileSync(SETTINGS_PATH, "utf-8");
   return SettingsSchema.parse(JSON.parse(content));

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -18,6 +18,8 @@ const PACKAGES_IMAGE = "code-container-packages";
 const BASE_IMAGE = "code-container-base";
 export type BuildTarget = "full" | "packages" | "harness" | "user";
 
+export const CONTAINER_USER = "developer";
+
 const RESOURCES_DIR = path.resolve(__dirname, "..", "resources");
 const CORE_DOCKERFILE = path.join(RESOURCES_DIR, "Dockerfile.Core");
 const HARNESS_DOCKERFILE = path.join(RESOURCES_DIR, "Dockerfile.Harness");
@@ -80,7 +82,7 @@ export function checkDocker(): void {
 
 export function getMounts(projectPath: string, projectName: string): string[] {
   const mounts: string[] = [];
-  mounts.push(`${projectPath}:/root/${projectName}`);
+  mounts.push(`${projectPath}:/home/${CONTAINER_USER}/${projectName}`);
   const fileMounts = loadMounts();
   mounts.push(...fileMounts);
   return mounts;
@@ -119,7 +121,11 @@ function ensureUserDockerfile(filePath: string, packagedSource: string): void {
   }
 }
 
-export function buildImageRaw(target: BuildTarget): boolean {
+export function buildImageRaw(
+  target: BuildTarget,
+  uid: number,
+  gid: number,
+): boolean {
   const startIndex = BUILD_START_INDEX[target];
 
   for (let i = startIndex; i < BUILD_STAGES.length; i++) {
@@ -130,19 +136,23 @@ export function buildImageRaw(target: BuildTarget): boolean {
       ensureUserDockerfile(stage.dockerfile, stage.packagedSource);
     }
 
-    const result = spawnSync(
-      "docker",
-      [
-        "build",
-        "--no-cache",
-        "-t",
-        `${stage.tag}:${IMAGE_TAG}`,
-        "-f",
-        stage.dockerfile,
-        APPDATA_DIR,
-      ],
-      { stdio: "inherit" },
-    );
+    const dockerArgs = [
+      "build",
+      "--no-cache",
+      "-t",
+      `${stage.tag}:${IMAGE_TAG}`,
+      "-f",
+      stage.dockerfile,
+    ];
+
+    if (i === 0) {
+      dockerArgs.push("--build-arg", `CONTAINER_UID=${uid}`);
+      dockerArgs.push("--build-arg", `CONTAINER_GID=${gid}`);
+    }
+
+    dockerArgs.push(APPDATA_DIR);
+
+    const result = spawnSync("docker", dockerArgs, { stdio: "inherit" });
     if (result.status !== 0) return false;
   }
 
@@ -188,7 +198,8 @@ export function createNewContainer(
 
   args.push("-e", "TERM=xterm-256color");
   args.push("-e", "COLORTERM=truecolor");
-  args.push("-w", `/root/${projectName}`);
+  args.push("--user", CONTAINER_USER);
+  args.push("-w", `/home/${CONTAINER_USER}/${projectName}`);
 
   for (const mount of mounts) {
     args.push("-v", mount);
@@ -206,10 +217,21 @@ export function createNewContainer(
   return result.status === 0;
 }
 
+export function getContainerUser(containerName: string): string {
+  const result = spawnSync(
+    "docker",
+    ["container", "inspect", "-f", "{{.Config.User}}", containerName],
+    { stdio: "pipe", encoding: "utf-8" },
+  );
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
 export function execInteractive(
   containerName: string,
   projectName: string,
 ): void {
+  const user = getContainerUser(containerName) || "root";
+  const homeDir = user === CONTAINER_USER ? `/home/${CONTAINER_USER}` : "/root";
   const flags = loadFlags(FlagSource.Common);
   spawnSync(
     "docker",
@@ -220,8 +242,10 @@ export function execInteractive(
       "TERM=xterm-256color",
       "-e",
       "COLORTERM=truecolor",
+      "--user",
+      user,
       "-w",
-      `/root/${projectName}`,
+      `${homeDir}/${projectName}`,
       ...flags,
       containerName,
       "/bin/bash",
@@ -247,7 +271,9 @@ export function getOtherSessionCount(
     const hasIt = line.includes("-it");
     const hasContainerName = line.includes(containerName);
     const hasBash = line.includes("/bin/bash");
-    const hasWorkdir = line.includes(`-w /root/${projectName}`);
+    const hasWorkdir =
+      line.includes(`-w /home/${CONTAINER_USER}/${projectName}`) ||
+      line.includes(`-w /root/${projectName}`);
 
     if (hasDockerExec && hasIt && hasContainerName && hasBash && hasWorkdir) {
       count++;

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -7,6 +7,7 @@ import {
   APPDATA_DIR,
   USER_DOCKERFILE_PATH,
   PACKAGES_DOCKERFILE_PATH,
+  HARNESS_LIST,
 } from "./config";
 import { loadMounts } from "./mounts";
 import { loadFlags, FlagSource } from "./flags";
@@ -68,6 +69,14 @@ const BUILD_START_INDEX: Record<BuildTarget, number> = {
   user: 3,
 };
 
+const HARNESS_BUILD_ARGS: Record<string, string> = {
+  "claude-code": "INSTALL_CLAUDE",
+  opencode: "INSTALL_OPENCODE",
+  codex: "INSTALL_CODEX",
+  gemini: "INSTALL_GEMINI",
+  copilot: "INSTALL_COPILOT",
+};
+
 const CONTAINER_PREFIX = "container";
 
 export function checkDocker(): void {
@@ -125,6 +134,7 @@ export function buildImageRaw(
   target: BuildTarget,
   uid: number,
   gid: number,
+  harnesses: string[],
 ): boolean {
   const startIndex = BUILD_START_INDEX[target];
 
@@ -148,6 +158,19 @@ export function buildImageRaw(
     if (i === 0) {
       dockerArgs.push("--build-arg", `CONTAINER_UID=${uid}`);
       dockerArgs.push("--build-arg", `CONTAINER_GID=${gid}`);
+    }
+
+    if (i === 2) {
+      dockerArgs.push("--build-arg", `CONTAINER_USER=${CONTAINER_USER}`);
+      for (const harness of HARNESS_LIST) {
+        const argName = HARNESS_BUILD_ARGS[harness];
+        if (argName) {
+          dockerArgs.push(
+            "--build-arg",
+            `${argName}=${harnesses.includes(harness) ? "true" : "false"}`,
+          );
+        }
+      }
     }
 
     dockerArgs.push(APPDATA_DIR);

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ async function main(): Promise<void> {
       cleanContainers();
       return;
     case "build":
-      buildImage(parsed.target);
+      await buildImage(parsed.target);
       return;
     case "stop": {
       const resolved = resolveProjectPath(parsed.projectPath);

--- a/src/mounts.ts
+++ b/src/mounts.ts
@@ -6,15 +6,15 @@ import { printInfo, promptYesNo } from "./utils";
 function getCoreMounts(): string[] {
   const home = os.homedir();
   return [
-    `${CONFIGS_DIR}/.claude:/root/.claude`,
-    `${CONFIGS_DIR}/.claude.json:/root/.claude.json`,
-    `${CONFIGS_DIR}/.codex:/root/.codex`,
-    `${CONFIGS_DIR}/.copilot:/root/.copilot`,
-    `${CONFIGS_DIR}/.opencode:/root/.config/opencode`,
-    `${CONFIGS_DIR}/.gemini:/root/.gemini`,
-    `${CONFIGS_DIR}/.local/share:/root/.local/share`,
-    `${CONFIGS_DIR}/.local/state:/root/.local/state`,
-    `${home}/.gitconfig:/root/.gitconfig:ro`,
+    `${CONFIGS_DIR}/.claude:/home/developer/.claude`,
+    `${CONFIGS_DIR}/.claude.json:/home/developer/.claude.json`,
+    `${CONFIGS_DIR}/.codex:/home/developer/.codex`,
+    `${CONFIGS_DIR}/.copilot:/home/developer/.copilot`,
+    `${CONFIGS_DIR}/.opencode:/home/developer/.config/opencode`,
+    `${CONFIGS_DIR}/.gemini:/home/developer/.gemini`,
+    `${CONFIGS_DIR}/.local/share:/home/developer/.local/share`,
+    `${CONFIGS_DIR}/.local/state:/home/developer/.local/state`,
+    `${home}/.gitconfig:/home/developer/.gitconfig:ro`,
   ];
 }
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -39,9 +39,11 @@ vi.mock("../src/config", () => ({
     acceptedTos: false,
     containerUid: 1000,
     containerGid: 1000,
+    selectedHarnesses: [],
   })),
   saveSettings: vi.fn(),
   copyConfigs: vi.fn(),
+  HARNESS_LIST: ["claude-code", "opencode", "codex", "gemini", "copilot"],
 }));
 
 vi.mock("../src/utils", () => ({
@@ -89,35 +91,106 @@ beforeEach(() => {
 });
 
 describe("buildImage", () => {
-  it("builds full target", () => {
-    buildImage("full");
-    expect(buildImageRaw).toHaveBeenCalledWith("full", 1000, 1000);
+  it("builds full target with stored harnesses", async () => {
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      completedInit: true,
+      acceptedTos: true,
+      containerUid: 1000,
+      containerGid: 1000,
+      selectedHarnesses: ["opencode", "codex"],
+    });
+    await buildImage("full");
+    expect(buildImageRaw).toHaveBeenCalledWith("full", 1000, 1000, [
+      "opencode",
+      "codex",
+    ]);
     expect(printSuccess).toHaveBeenCalled();
   });
 
-  it("builds packages target", () => {
-    buildImage("packages");
-    expect(buildImageRaw).toHaveBeenCalledWith("packages", 1000, 1000);
+  it("prompts for harnesses when none selected", async () => {
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      completedInit: true,
+      acceptedTos: true,
+      containerUid: 1000,
+      containerGid: 1000,
+      selectedHarnesses: [],
+    });
+    vi.mocked(promptYesNo)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    await buildImage("full");
+    expect(buildImageRaw).toHaveBeenCalledWith("full", 1000, 1000, [
+      "claude-code",
+      "opencode",
+      "gemini",
+    ]);
+    expect(saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedHarnesses: ["claude-code", "opencode", "gemini"],
+      }),
+    );
   });
 
-  it("builds harness target", () => {
-    buildImage("harness");
-    expect(buildImageRaw).toHaveBeenCalledWith("harness", 1000, 1000);
+  it("builds packages target", async () => {
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      completedInit: true,
+      acceptedTos: true,
+      containerUid: 1000,
+      containerGid: 1000,
+      selectedHarnesses: ["opencode"],
+    });
+    await buildImage("packages");
+    expect(buildImageRaw).toHaveBeenCalledWith("packages", 1000, 1000, [
+      "opencode",
+    ]);
   });
 
-  it("builds user target", () => {
-    buildImage("user");
-    expect(buildImageRaw).toHaveBeenCalledWith("user", 1000, 1000);
+  it("builds harness target", async () => {
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      completedInit: true,
+      acceptedTos: true,
+      containerUid: 1000,
+      containerGid: 1000,
+      selectedHarnesses: ["codex"],
+    });
+    await buildImage("harness");
+    expect(buildImageRaw).toHaveBeenCalledWith("harness", 1000, 1000, [
+      "codex",
+    ]);
   });
 
-  it("calls process.exit on build failure", () => {
+  it("builds user target", async () => {
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      completedInit: true,
+      acceptedTos: true,
+      containerUid: 1000,
+      containerGid: 1000,
+      selectedHarnesses: ["gemini"],
+    });
+    await buildImage("user");
+    expect(buildImageRaw).toHaveBeenCalledWith("user", 1000, 1000, ["gemini"]);
+  });
+
+  it("calls process.exit on build failure", async () => {
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      completedInit: true,
+      acceptedTos: true,
+      containerUid: 1000,
+      containerGid: 1000,
+      selectedHarnesses: ["opencode"],
+    });
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
     vi.mocked(buildImageRaw).mockReturnValueOnce(false);
-    expect(() => buildImage("full")).toThrow("process.exit");
+    await expect(buildImage("full")).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(buildImageRaw).toHaveBeenCalledWith("full", 1000, 1000);
+    expect(buildImageRaw).toHaveBeenCalledWith("full", 1000, 1000, [
+      "opencode",
+    ]);
     exitSpy.mockRestore();
   });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -34,7 +34,12 @@ vi.mock("../src/docker", () => ({
 
 vi.mock("../src/config", () => ({
   ensureConfigDir: vi.fn(),
-  loadSettings: vi.fn(() => ({ completedInit: false, acceptedTos: false })),
+  loadSettings: vi.fn(() => ({
+    completedInit: false,
+    acceptedTos: false,
+    containerUid: 1000,
+    containerGid: 1000,
+  })),
   saveSettings: vi.fn(),
   copyConfigs: vi.fn(),
 }));
@@ -86,23 +91,23 @@ beforeEach(() => {
 describe("buildImage", () => {
   it("builds full target", () => {
     buildImage("full");
-    expect(buildImageRaw).toHaveBeenCalledWith("full");
+    expect(buildImageRaw).toHaveBeenCalledWith("full", 1000, 1000);
     expect(printSuccess).toHaveBeenCalled();
   });
 
   it("builds packages target", () => {
     buildImage("packages");
-    expect(buildImageRaw).toHaveBeenCalledWith("packages");
+    expect(buildImageRaw).toHaveBeenCalledWith("packages", 1000, 1000);
   });
 
   it("builds harness target", () => {
     buildImage("harness");
-    expect(buildImageRaw).toHaveBeenCalledWith("harness");
+    expect(buildImageRaw).toHaveBeenCalledWith("harness", 1000, 1000);
   });
 
   it("builds user target", () => {
     buildImage("user");
-    expect(buildImageRaw).toHaveBeenCalledWith("user");
+    expect(buildImageRaw).toHaveBeenCalledWith("user", 1000, 1000);
   });
 
   it("calls process.exit on build failure", () => {
@@ -112,7 +117,7 @@ describe("buildImage", () => {
     vi.mocked(buildImageRaw).mockReturnValueOnce(false);
     expect(() => buildImage("full")).toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(buildImageRaw).toHaveBeenCalledWith("full");
+    expect(buildImageRaw).toHaveBeenCalledWith("full", 1000, 1000);
     exitSpy.mockRestore();
   });
 });
@@ -138,6 +143,8 @@ describe("init", () => {
     vi.mocked(loadSettings).mockReturnValueOnce({
       completedInit: true,
       acceptedTos: false,
+      containerUid: 1000,
+      containerGid: 1000,
     });
     await init(true);
     expect(promptYesNo).not.toHaveBeenCalled();
@@ -149,6 +156,8 @@ describe("init", () => {
     vi.mocked(loadSettings).mockReturnValueOnce({
       completedInit: false,
       acceptedTos: false,
+      containerUid: 1000,
+      containerGid: 1000,
     });
     await init(false);
     expect(copyConfigs).toHaveBeenCalled();
@@ -159,6 +168,8 @@ describe("init", () => {
     vi.mocked(loadSettings).mockReturnValueOnce({
       completedInit: true,
       acceptedTos: false,
+      containerUid: 1000,
+      containerGid: 1000,
     });
     vi.mocked(promptYesNo).mockResolvedValueOnce(true);
     await init(false);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -21,19 +21,39 @@ beforeEach(() => {
 
 describe("loadSettings", () => {
   it("returns defaults when file does not exist", () => {
-    expect(loadSettings()).toEqual({
-      completedInit: false,
-      acceptedTos: false,
-    });
+    const settings = loadSettings();
+    expect(settings.completedInit).toBe(false);
+    expect(settings.acceptedTos).toBe(false);
+    expect(settings.containerUid).toBe(1000);
+    expect(settings.containerGid).toBe(1000);
   });
 
   it("returns parsed settings from valid JSON", () => {
     fs.mkdirSync(APPDATA_DIR, { recursive: true });
     fs.writeFileSync(
       SETTINGS_PATH,
-      JSON.stringify({ completedInit: true, acceptedTos: true }),
+      JSON.stringify({
+        completedInit: true,
+        acceptedTos: true,
+        containerUid: 1001,
+        containerGid: 1002,
+      }),
     );
-    expect(loadSettings()).toEqual({ completedInit: true, acceptedTos: true });
+    expect(loadSettings()).toEqual({
+      completedInit: true,
+      acceptedTos: true,
+      containerUid: 1001,
+      containerGid: 1002,
+    });
+  });
+
+  it("applies defaults for missing UID/GID fields", () => {
+    fs.mkdirSync(APPDATA_DIR, { recursive: true });
+    fs.writeFileSync(SETTINGS_PATH, JSON.stringify({ completedInit: true }));
+    const settings = loadSettings();
+    expect(settings.completedInit).toBe(true);
+    expect(settings.containerUid).toBe(1000);
+    expect(settings.containerGid).toBe(1000);
   });
 
   it("throws on invalid JSON", () => {
@@ -54,11 +74,18 @@ describe("loadSettings", () => {
 
 describe("saveSettings", () => {
   it("writes settings as JSON and creates appdata dir", () => {
-    saveSettings({ completedInit: true, acceptedTos: false });
+    saveSettings({
+      completedInit: true,
+      acceptedTos: false,
+      containerUid: 1000,
+      containerGid: 1000,
+    });
     const content = fs.readFileSync(SETTINGS_PATH, "utf-8") as string;
     expect(JSON.parse(content)).toEqual({
       completedInit: true,
       acceptedTos: false,
+      containerUid: 1000,
+      containerGid: 1000,
     });
     expect(fs.existsSync(APPDATA_DIR)).toBe(true);
   });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -26,6 +26,7 @@ describe("loadSettings", () => {
     expect(settings.acceptedTos).toBe(false);
     expect(settings.containerUid).toBe(1000);
     expect(settings.containerGid).toBe(1000);
+    expect(settings.selectedHarnesses).toEqual([]);
   });
 
   it("returns parsed settings from valid JSON", () => {
@@ -37,6 +38,7 @@ describe("loadSettings", () => {
         acceptedTos: true,
         containerUid: 1001,
         containerGid: 1002,
+        selectedHarnesses: ["opencode", "codex"],
       }),
     );
     expect(loadSettings()).toEqual({
@@ -44,6 +46,7 @@ describe("loadSettings", () => {
       acceptedTos: true,
       containerUid: 1001,
       containerGid: 1002,
+      selectedHarnesses: ["opencode", "codex"],
     });
   });
 
@@ -54,6 +57,7 @@ describe("loadSettings", () => {
     expect(settings.completedInit).toBe(true);
     expect(settings.containerUid).toBe(1000);
     expect(settings.containerGid).toBe(1000);
+    expect(settings.selectedHarnesses).toEqual([]);
   });
 
   it("throws on invalid JSON", () => {
@@ -79,6 +83,7 @@ describe("saveSettings", () => {
       acceptedTos: false,
       containerUid: 1000,
       containerGid: 1000,
+      selectedHarnesses: ["opencode"],
     });
     const content = fs.readFileSync(SETTINGS_PATH, "utf-8") as string;
     expect(JSON.parse(content)).toEqual({
@@ -86,6 +91,7 @@ describe("saveSettings", () => {
       acceptedTos: false,
       containerUid: 1000,
       containerGid: 1000,
+      selectedHarnesses: ["opencode"],
     });
     expect(fs.existsSync(APPDATA_DIR)).toBe(true);
   });

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -359,7 +359,7 @@ describe("buildImageRaw", () => {
     it("builds all 4 stages", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      const result = buildImageRaw("full", 1000, 1001);
+      const result = buildImageRaw("full", 1000, 1001, []);
       expect(result).toBe(true);
 
       const builds = getBuildCalls();
@@ -369,7 +369,7 @@ describe("buildImageRaw", () => {
     it("passes --no-cache to every stage", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      buildImageRaw("full", 1000, 1001);
+      buildImageRaw("full", 1000, 1001, []);
 
       const builds = getBuildCalls();
       for (const build of builds) {
@@ -380,7 +380,7 @@ describe("buildImageRaw", () => {
     it("uses correct dockerfile and tag for each stage", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      buildImageRaw("full", 1000, 1001);
+      buildImageRaw("full", 1000, 1001, []);
 
       const builds = getBuildCalls();
       expect(builds[0].dockerfile).toBe(coreDockerfile);
@@ -399,7 +399,7 @@ describe("buildImageRaw", () => {
     it("passes UID/GID build args to core stage (index 0)", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      buildImageRaw("full", 1000, 1001);
+      buildImageRaw("full", 1000, 1001, []);
 
       const builds = getBuildCalls();
       const coreArgs = builds[0].args;
@@ -411,7 +411,7 @@ describe("buildImageRaw", () => {
     it("does not pass UID/GID args to non-core stages", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      buildImageRaw("full", 1000, 1001);
+      buildImageRaw("full", 1000, 1001, []);
 
       const builds = getBuildCalls();
       for (let i = 1; i < builds.length; i++) {
@@ -420,10 +420,49 @@ describe("buildImageRaw", () => {
       }
     });
 
+    it("passes harness build args to harness stage (index 2)", () => {
+      seedAllDockerfiles();
+      enqueueSuccessfulBuilds(4);
+      buildImageRaw("full", 1000, 1001, ["opencode", "gemini"]);
+
+      const builds = getBuildCalls();
+      const harnessArgs = builds[2].args;
+      expect(harnessArgs).toContain("--build-arg");
+      expect(harnessArgs).toContain("INSTALL_CLAUDE=false");
+      expect(harnessArgs).toContain("INSTALL_OPENCODE=true");
+      expect(harnessArgs).toContain("INSTALL_CODEX=false");
+      expect(harnessArgs).toContain("INSTALL_GEMINI=true");
+      expect(harnessArgs).toContain("INSTALL_COPILOT=false");
+    });
+
+    it("passes CONTAINER_USER to harness stage", () => {
+      seedAllDockerfiles();
+      enqueueSuccessfulBuilds(4);
+      buildImageRaw("full", 1000, 1001, []);
+
+      const builds = getBuildCalls();
+      const harnessArgs = builds[2].args;
+      expect(harnessArgs).toContain("--build-arg");
+      expect(harnessArgs).toContain("CONTAINER_USER=developer");
+    });
+
+    it("does not pass harness args to non-harness stages", () => {
+      seedAllDockerfiles();
+      enqueueSuccessfulBuilds(4);
+      buildImageRaw("full", 1000, 1001, ["opencode"]);
+
+      const builds = getBuildCalls();
+      for (let i = 0; i < builds.length; i++) {
+        if (i === 2) continue;
+        expect(builds[i].args).not.toContain("INSTALL_CLAUDE");
+        expect(builds[i].args).not.toContain("INSTALL_OPENCODE");
+      }
+    });
+
     it("uses APPDATA_DIR as build context for every stage", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      buildImageRaw("full", 1000, 1001);
+      buildImageRaw("full", 1000, 1001, []);
 
       const builds = getBuildCalls();
       for (const build of builds) {
@@ -436,7 +475,7 @@ describe("buildImageRaw", () => {
     it("builds 3 stages (packages, harness, user)", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(3);
-      const result = buildImageRaw("packages", 1000, 1001);
+      const result = buildImageRaw("packages", 1000, 1001, []);
       expect(result).toBe(true);
 
       const builds = getBuildCalls();
@@ -449,7 +488,7 @@ describe("buildImageRaw", () => {
     it("does not build core stage", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(3);
-      buildImageRaw("packages", 1000, 1001);
+      buildImageRaw("packages", 1000, 1001, []);
 
       const builds = getBuildCalls();
       const coreBuild = builds.find((b) => b.dockerfile === coreDockerfile);
@@ -461,7 +500,7 @@ describe("buildImageRaw", () => {
     it("builds 2 stages (harness, user)", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(2);
-      const result = buildImageRaw("harness", 1000, 1001);
+      const result = buildImageRaw("harness", 1000, 1001, []);
       expect(result).toBe(true);
 
       const builds = getBuildCalls();
@@ -473,7 +512,7 @@ describe("buildImageRaw", () => {
     it("does not build core or packages stages", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(2);
-      buildImageRaw("harness", 1000, 1001);
+      buildImageRaw("harness", 1000, 1001, []);
 
       const builds = getBuildCalls();
       const coreBuild = builds.find((b) => b.dockerfile === coreDockerfile);
@@ -489,7 +528,7 @@ describe("buildImageRaw", () => {
     it("builds only the user stage", () => {
       seedAllDockerfiles();
       enqueue({ status: 0, stdout: "", stderr: "" });
-      const result = buildImageRaw("user", 1000, 1001);
+      const result = buildImageRaw("user", 1000, 1001, []);
       expect(result).toBe(true);
 
       const builds = getBuildCalls();
@@ -503,7 +542,7 @@ describe("buildImageRaw", () => {
     it("returns false when core stage fails", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("full", 1000, 1001)).toBe(false);
+      expect(buildImageRaw("full", 1000, 1001, [])).toBe(false);
       expect(getBuildCalls()).toHaveLength(1);
     });
 
@@ -511,7 +550,7 @@ describe("buildImageRaw", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(1);
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("full", 1000, 1001)).toBe(false);
+      expect(buildImageRaw("full", 1000, 1001, [])).toBe(false);
       expect(getBuildCalls()).toHaveLength(2);
     });
 
@@ -519,7 +558,7 @@ describe("buildImageRaw", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(2);
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("full", 1000, 1001)).toBe(false);
+      expect(buildImageRaw("full", 1000, 1001, [])).toBe(false);
       expect(getBuildCalls()).toHaveLength(3);
     });
 
@@ -527,35 +566,35 @@ describe("buildImageRaw", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(3);
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("full", 1000, 1001)).toBe(false);
+      expect(buildImageRaw("full", 1000, 1001, [])).toBe(false);
       expect(getBuildCalls()).toHaveLength(4);
     });
 
     it("does not continue building after a failure", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      buildImageRaw("full", 1000, 1001);
+      buildImageRaw("full", 1000, 1001, []);
       expect(getBuildCalls()).toHaveLength(1);
     });
 
     it("packages target fails at first stage", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("packages", 1000, 1001)).toBe(false);
+      expect(buildImageRaw("packages", 1000, 1001, [])).toBe(false);
       expect(getBuildCalls()).toHaveLength(1);
     });
 
     it("harness target fails at first stage", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("harness", 1000, 1001)).toBe(false);
+      expect(buildImageRaw("harness", 1000, 1001, [])).toBe(false);
       expect(getBuildCalls()).toHaveLength(1);
     });
 
     it("user target fails", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("user", 1000, 1001)).toBe(false);
+      expect(buildImageRaw("user", 1000, 1001, [])).toBe(false);
     });
   });
 
@@ -568,7 +607,7 @@ describe("buildImageRaw", () => {
       });
       enqueueSuccessfulBuilds(1);
 
-      buildImageRaw("packages", 1000, 1001);
+      buildImageRaw("packages", 1000, 1001, []);
 
       expect(
         // @ts-expect-error memfs runtime has existsSync but types don't expose it
@@ -586,7 +625,7 @@ describe("buildImageRaw", () => {
       });
       enqueueSuccessfulBuilds(1);
 
-      buildImageRaw("user", 1000, 1001);
+      buildImageRaw("user", 1000, 1001, []);
 
       expect(
         // @ts-expect-error memfs runtime has existsSync but types don't expose it
@@ -597,7 +636,7 @@ describe("buildImageRaw", () => {
     });
 
     it("throws when user dockerfile and packaged source both missing", () => {
-      expect(() => buildImageRaw("user", 1000, 1001)).toThrow(
+      expect(() => buildImageRaw("user", 1000, 1001, [])).toThrow(
         "Dockerfile not found",
       );
     });
@@ -612,7 +651,7 @@ describe("buildImageRaw", () => {
         path.join(os.homedir(), ".code-container", "Dockerfile.User"),
         "utf-8",
       );
-      buildImageRaw("user", 1000, 1001);
+      buildImageRaw("user", 1000, 1001, []);
       // @ts-expect-error memfs runtime has readFileSync but types don't expose it
       const contentAfter = fs.readFileSync(
         path.join(os.homedir(), ".code-container", "Dockerfile.User"),

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -13,6 +13,7 @@ import {
   generateContainerName,
   getStoppedContainerIds,
   buildImageRaw,
+  getContainerUser,
 } from "../src/docker";
 
 vi.mock("fs");
@@ -107,6 +108,23 @@ describe("containerRunning", () => {
   });
 });
 
+describe("getContainerUser", () => {
+  it("returns empty string when container not found", () => {
+    enqueue({ status: 1, stdout: "", stderr: "" });
+    expect(getContainerUser("container-foo-abc12345")).toBe("");
+  });
+
+  it("returns configured user for container", () => {
+    enqueue({ status: 0, stdout: "developer\n", stderr: "" });
+    expect(getContainerUser("container-foo-abc12345")).toBe("developer");
+  });
+
+  it("returns empty string for root (old containers)", () => {
+    enqueue({ status: 0, stdout: "\n", stderr: "" });
+    expect(getContainerUser("container-foo-abc12345")).toBe("");
+  });
+});
+
 describe("getOtherSessionCount", () => {
   it("returns 0 when ps fails", () => {
     enqueue({ status: 1, stdout: "", stderr: "" });
@@ -117,19 +135,29 @@ describe("getOtherSessionCount", () => {
     enqueue({
       status: 0,
       stdout:
-        "docker exec -it -w /root/foo container-foo-abc12345 /bin/bash\n" +
-        "docker exec -it -w /root/foo container-foo-abc12345 /bin/bash\n" +
+        "docker exec -it --user developer -w /home/developer/foo container-foo-abc12345 /bin/bash\n" +
+        "docker exec -it --user developer -w /home/developer/foo container-foo-abc12345 /bin/bash\n" +
         "some other process\n",
       stderr: "",
     });
     expect(getOtherSessionCount("container-foo-abc12345", "foo")).toBe(2);
   });
 
+  it("counts old container sessions with /root/ workdir", () => {
+    enqueue({
+      status: 0,
+      stdout:
+        "docker exec -it --user root -w /root/foo container-foo-abc12345 /bin/bash\n",
+      stderr: "",
+    });
+    expect(getOtherSessionCount("container-foo-abc12345", "foo")).toBe(1);
+  });
+
   it("does not count non-matching sessions", () => {
     enqueue({
       status: 0,
       stdout:
-        "docker exec -it -w /root/bar container-bar-xyz /bin/bash\n" +
+        "docker exec -it --user developer -w /home/developer/bar container-bar-xyz /bin/bash\n" +
         "ps ax -o command=\n",
       stderr: "",
     });
@@ -150,7 +178,8 @@ describe("stopContainerIfLastSession", () => {
   it("skips stop when other sessions exist", () => {
     enqueue({
       status: 0,
-      stdout: "docker exec -it -w /root/foo container-foo-abc12345 /bin/bash\n",
+      stdout:
+        "docker exec -it --user developer -w /home/developer/foo container-foo-abc12345 /bin/bash\n",
       stderr: "",
     });
     stopContainerIfLastSession("container-foo-abc12345", "foo");
@@ -174,10 +203,12 @@ describe("createNewContainer", () => {
     expect(runCall.args).toContain("container-foo-abc12345");
     expect(runCall.args).toContain("-e");
     expect(runCall.args).toContain("TERM=xterm-256color");
+    expect(runCall.args).toContain("--user");
+    expect(runCall.args).toContain("developer");
     expect(runCall.args).toContain("-w");
-    expect(runCall.args).toContain("/root/foo");
+    expect(runCall.args).toContain("/home/developer/foo");
     expect(runCall.args).toContain("-v");
-    expect(runCall.args).toContain("/home/user/foo:/root/foo");
+    expect(runCall.args).toContain("/home/user/foo:/home/developer/foo");
     expect(runCall.args![runCall.args!.length - 3]).toBe(
       "code-container:latest",
     );
@@ -328,7 +359,7 @@ describe("buildImageRaw", () => {
     it("builds all 4 stages", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      const result = buildImageRaw("full");
+      const result = buildImageRaw("full", 1000, 1001);
       expect(result).toBe(true);
 
       const builds = getBuildCalls();
@@ -338,7 +369,7 @@ describe("buildImageRaw", () => {
     it("passes --no-cache to every stage", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      buildImageRaw("full");
+      buildImageRaw("full", 1000, 1001);
 
       const builds = getBuildCalls();
       for (const build of builds) {
@@ -349,7 +380,7 @@ describe("buildImageRaw", () => {
     it("uses correct dockerfile and tag for each stage", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      buildImageRaw("full");
+      buildImageRaw("full", 1000, 1001);
 
       const builds = getBuildCalls();
       expect(builds[0].dockerfile).toBe(coreDockerfile);
@@ -365,10 +396,34 @@ describe("buildImageRaw", () => {
       expect(builds[3].tag).toBe("code-container:latest");
     });
 
+    it("passes UID/GID build args to core stage (index 0)", () => {
+      seedAllDockerfiles();
+      enqueueSuccessfulBuilds(4);
+      buildImageRaw("full", 1000, 1001);
+
+      const builds = getBuildCalls();
+      const coreArgs = builds[0].args;
+      expect(coreArgs).toContain("--build-arg");
+      expect(coreArgs).toContain("CONTAINER_UID=1000");
+      expect(coreArgs).toContain("CONTAINER_GID=1001");
+    });
+
+    it("does not pass UID/GID args to non-core stages", () => {
+      seedAllDockerfiles();
+      enqueueSuccessfulBuilds(4);
+      buildImageRaw("full", 1000, 1001);
+
+      const builds = getBuildCalls();
+      for (let i = 1; i < builds.length; i++) {
+        expect(builds[i].args).not.toContain("CONTAINER_UID");
+        expect(builds[i].args).not.toContain("CONTAINER_GID");
+      }
+    });
+
     it("uses APPDATA_DIR as build context for every stage", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(4);
-      buildImageRaw("full");
+      buildImageRaw("full", 1000, 1001);
 
       const builds = getBuildCalls();
       for (const build of builds) {
@@ -381,7 +436,7 @@ describe("buildImageRaw", () => {
     it("builds 3 stages (packages, harness, user)", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(3);
-      const result = buildImageRaw("packages");
+      const result = buildImageRaw("packages", 1000, 1001);
       expect(result).toBe(true);
 
       const builds = getBuildCalls();
@@ -394,7 +449,7 @@ describe("buildImageRaw", () => {
     it("does not build core stage", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(3);
-      buildImageRaw("packages");
+      buildImageRaw("packages", 1000, 1001);
 
       const builds = getBuildCalls();
       const coreBuild = builds.find((b) => b.dockerfile === coreDockerfile);
@@ -406,7 +461,7 @@ describe("buildImageRaw", () => {
     it("builds 2 stages (harness, user)", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(2);
-      const result = buildImageRaw("harness");
+      const result = buildImageRaw("harness", 1000, 1001);
       expect(result).toBe(true);
 
       const builds = getBuildCalls();
@@ -418,7 +473,7 @@ describe("buildImageRaw", () => {
     it("does not build core or packages stages", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(2);
-      buildImageRaw("harness");
+      buildImageRaw("harness", 1000, 1001);
 
       const builds = getBuildCalls();
       const coreBuild = builds.find((b) => b.dockerfile === coreDockerfile);
@@ -434,7 +489,7 @@ describe("buildImageRaw", () => {
     it("builds only the user stage", () => {
       seedAllDockerfiles();
       enqueue({ status: 0, stdout: "", stderr: "" });
-      const result = buildImageRaw("user");
+      const result = buildImageRaw("user", 1000, 1001);
       expect(result).toBe(true);
 
       const builds = getBuildCalls();
@@ -448,7 +503,7 @@ describe("buildImageRaw", () => {
     it("returns false when core stage fails", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("full")).toBe(false);
+      expect(buildImageRaw("full", 1000, 1001)).toBe(false);
       expect(getBuildCalls()).toHaveLength(1);
     });
 
@@ -456,7 +511,7 @@ describe("buildImageRaw", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(1);
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("full")).toBe(false);
+      expect(buildImageRaw("full", 1000, 1001)).toBe(false);
       expect(getBuildCalls()).toHaveLength(2);
     });
 
@@ -464,7 +519,7 @@ describe("buildImageRaw", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(2);
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("full")).toBe(false);
+      expect(buildImageRaw("full", 1000, 1001)).toBe(false);
       expect(getBuildCalls()).toHaveLength(3);
     });
 
@@ -472,35 +527,35 @@ describe("buildImageRaw", () => {
       seedAllDockerfiles();
       enqueueSuccessfulBuilds(3);
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("full")).toBe(false);
+      expect(buildImageRaw("full", 1000, 1001)).toBe(false);
       expect(getBuildCalls()).toHaveLength(4);
     });
 
     it("does not continue building after a failure", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      buildImageRaw("full");
+      buildImageRaw("full", 1000, 1001);
       expect(getBuildCalls()).toHaveLength(1);
     });
 
     it("packages target fails at first stage", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("packages")).toBe(false);
+      expect(buildImageRaw("packages", 1000, 1001)).toBe(false);
       expect(getBuildCalls()).toHaveLength(1);
     });
 
     it("harness target fails at first stage", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("harness")).toBe(false);
+      expect(buildImageRaw("harness", 1000, 1001)).toBe(false);
       expect(getBuildCalls()).toHaveLength(1);
     });
 
     it("user target fails", () => {
       seedAllDockerfiles();
       enqueue({ status: 1, stdout: "", stderr: "" });
-      expect(buildImageRaw("user")).toBe(false);
+      expect(buildImageRaw("user", 1000, 1001)).toBe(false);
     });
   });
 
@@ -513,7 +568,7 @@ describe("buildImageRaw", () => {
       });
       enqueueSuccessfulBuilds(1);
 
-      buildImageRaw("packages");
+      buildImageRaw("packages", 1000, 1001);
 
       expect(
         // @ts-expect-error memfs runtime has existsSync but types don't expose it
@@ -531,7 +586,7 @@ describe("buildImageRaw", () => {
       });
       enqueueSuccessfulBuilds(1);
 
-      buildImageRaw("user");
+      buildImageRaw("user", 1000, 1001);
 
       expect(
         // @ts-expect-error memfs runtime has existsSync but types don't expose it
@@ -542,7 +597,9 @@ describe("buildImageRaw", () => {
     });
 
     it("throws when user dockerfile and packaged source both missing", () => {
-      expect(() => buildImageRaw("user")).toThrow("Dockerfile not found");
+      expect(() => buildImageRaw("user", 1000, 1001)).toThrow(
+        "Dockerfile not found",
+      );
     });
 
     it("does not copy when user dockerfile already exists", () => {
@@ -555,7 +612,7 @@ describe("buildImageRaw", () => {
         path.join(os.homedir(), ".code-container", "Dockerfile.User"),
         "utf-8",
       );
-      buildImageRaw("user");
+      buildImageRaw("user", 1000, 1001);
       // @ts-expect-error memfs runtime has readFileSync but types don't expose it
       const contentAfter = fs.readFileSync(
         path.join(os.homedir(), ".code-container", "Dockerfile.User"),

--- a/tests/mounts.test.ts
+++ b/tests/mounts.test.ts
@@ -16,8 +16,10 @@ beforeEach(() => {
 describe("loadMounts", () => {
   it("returns core mounts when MOUNTS.txt does not exist", () => {
     const mounts = loadMounts();
-    expect(mounts).toContain(`${CONFIGS_DIR}/.claude:/root/.claude`);
-    expect(mounts).toContain(`${home}/.gitconfig:/root/.gitconfig:ro`);
+    expect(mounts).toContain(`${CONFIGS_DIR}/.claude:/home/developer/.claude`);
+    expect(mounts).toContain(
+      `${home}/.gitconfig:/home/developer/.gitconfig:ro`,
+    );
   });
 
   it("merges extra mounts from MOUNTS.txt", () => {
@@ -26,12 +28,12 @@ describe("loadMounts", () => {
 
     const mounts = loadMounts();
     expect(mounts).toContain("/host/path:/container/path");
-    expect(mounts).toContain(`${CONFIGS_DIR}/.claude:/root/.claude`);
+    expect(mounts).toContain(`${CONFIGS_DIR}/.claude:/home/developer/.claude`);
   });
 
   it("deduplicates mounts", () => {
     fs.mkdirSync(path.dirname(MOUNTS_PATH), { recursive: true });
-    const coreMount = `${CONFIGS_DIR}/.claude:/root/.claude`;
+    const coreMount = `${CONFIGS_DIR}/.claude:/home/developer/.claude`;
     fs.writeFileSync(MOUNTS_PATH, `${coreMount}\n`);
 
     const mounts = loadMounts();


### PR DESCRIPTION
## Summary
- **Non-root user**: Container runs as `developer` with host UID/GID; old containers gracefully fall back to root
- **Selectable harnesses**: User chooses which AI CLIs to install at `container build` time (stored in settings)

## Changes
### Non-root user
- `Dockerfile.Core`: ARGs after apt-get/nvm → cache-friendly; user creation with UID/GID conflict handling; `jq` added
- `docker.ts`: `getContainerUser()` inspects container user via `docker inspect`; fallback to root for old containers
- `mounts.ts`: paths changed from `/root/` to `/home/developer/`
- `getOtherSessionCount()` matches both old `/root/` and new `/home/developer/` workdirs

### Selectable harnesses
- `Dockerfile.Harness`: each harness gated by `ARG INSTALL_<NAME>=false`
- `config.ts`: `HARNESS_LIST`, `selectedHarnesses` in `SettingsSchema`
- `commands.ts`: `buildImage()` prompts for harness selection on first build, saves to settings
- `docker.ts`: `HARNESS_BUILD_ARGS` map, injects build args per harness

## Tests
- 140 tests all passing (+4 new tests: `getContainerUser`, old container `/root/` session counting)